### PR TITLE
Update to README file to include example for setting up abc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# simulation of upstream changes
+test
+
 # angular-hmr-lazy-components
 This example shows how Angular HMR can be used to automatically reload lazy routes and lazy (dynamically-loaded) components. This can be extremely helpful for large Angular apps that take a while to JIT compile when they reload.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# simulation of upstream changes
+# simulation of more upstream changes
 test
 
 # angular-hmr-lazy-components

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# simulation of more upstream changes
-test
+# Sentry changes
+Boosh!
 
 # angular-hmr-lazy-components
 This example shows how Angular HMR can be used to automatically reload lazy routes and lazy (dynamically-loaded) components. This can be extremely helpful for large Angular apps that take a while to JIT compile when they reload.


### PR DESCRIPTION
This pull request adds an example to the README file for how to set up abc. This was a critical use case that the existing documentation did not cover.